### PR TITLE
Apply minimal style refresh across navigation and categories

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -37,7 +37,7 @@ export const Header: React.FC = () => {
   };
 
   return (
-    <header className="sticky top-0 z-50 border-b border-border/80 bg-background/88 backdrop-blur-xl supports-[backdrop-filter]:bg-background/72">
+    <header className="sticky top-0 z-50 border-b border-border bg-background/90 backdrop-blur-xl supports-[backdrop-filter]:bg-background/80">
       <PageContainer className="py-3" contentClassName="flex items-center justify-between gap-4">
         <div className="flex min-w-0 items-center gap-3">
           {router.pathname !== '/' && (
@@ -47,7 +47,7 @@ export const Header: React.FC = () => {
             </Button>
           )}
           <Link href="/" className="min-w-0">
-            <p className="truncate text-sm font-medium tracking-[0.18em] text-foreground/70 uppercase">
+            <p className="truncate text-sm font-semibold tracking-tight text-foreground/90">
               WebToolBox
             </p>
           </Link>
@@ -55,7 +55,7 @@ export const Header: React.FC = () => {
 
         <div className="flex items-center gap-2 sm:gap-3">
           <Select value={language} onValueChange={(value) => setLanguage(value as Language)}>
-            <SelectTrigger className="h-10 w-[120px] rounded-full border-border/80 bg-card/80 sm:w-[140px]" data-testid="language-selector">
+            <SelectTrigger className="h-10 w-[120px] rounded-xl border-border bg-card sm:w-[140px]" data-testid="language-selector">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -69,7 +69,7 @@ export const Header: React.FC = () => {
 
           <button
             onClick={toggleTheme}
-            className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-input bg-card/80 transition-colors hover:bg-accent hover:text-accent-foreground"
+            className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-input bg-card transition-colors duration-100 hover:bg-accent hover:text-accent-foreground"
             aria-label={t('common.header.themeToggleAriaLabel')}
             data-testid="theme-toggle"
           >

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Link from 'next/link';
 import { useI18n } from '@/lib/i18n/i18nContext';
 import { useTheme } from '@/lib/theme/themeContext';
 import { Language } from '@/lib/i18n/translations';
@@ -36,18 +37,25 @@ export const Header: React.FC = () => {
   };
 
   return (
-    <header className="sticky top-0 z-50 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 border-b">
+    <header className="sticky top-0 z-50 border-b bg-background/90 backdrop-blur-xl supports-[backdrop-filter]:bg-background/75">
       <PageContainer className="py-3" contentClassName="flex items-center justify-between gap-4">
-        {router.pathname !== '/' ? (
-          <Button type="button" variant="outline" className="flex items-center" onClick={handleBack}>
-            <HiArrowLeft className="mr-2 h-4 w-4" />
-            {t('common.backToCategories')}
-          </Button>
-        ) : <div />}
+        <div className="flex min-w-0 items-center gap-3">
+          {router.pathname !== '/' && (
+            <Button type="button" variant="outline" className="px-4" onClick={handleBack}>
+              <HiArrowLeft className="mr-2 h-4 w-4" />
+              <span className="hidden sm:inline">{t('common.backToCategories')}</span>
+            </Button>
+          )}
+          <Link href="/" className="min-w-0">
+            <p className="truncate text-sm font-semibold tracking-[0.14em] text-foreground/80 uppercase">
+              WebToolBox
+            </p>
+          </Link>
+        </div>
 
-        <div className="flex items-center gap-3 sm:gap-4">
+        <div className="flex items-center gap-2 sm:gap-3">
           <Select value={language} onValueChange={(value) => setLanguage(value as Language)}>
-            <SelectTrigger className="w-[140px]" data-testid="language-selector">
+            <SelectTrigger className="h-10 w-[120px] rounded-full sm:w-[140px]" data-testid="language-selector">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -61,14 +69,14 @@ export const Header: React.FC = () => {
 
           <button
             onClick={toggleTheme}
-            className="rounded-md p-2 transition-colors hover:bg-accent hover:text-accent-foreground"
+            className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-input bg-background transition-colors hover:bg-accent hover:text-accent-foreground"
             aria-label={t('common.header.themeToggleAriaLabel')}
             data-testid="theme-toggle"
           >
             {theme === 'light' ? (
-              <HiMoon className="h-5 w-5" />
+              <HiMoon className="h-4 w-4" />
             ) : (
-              <HiSun className="h-5 w-5" />
+              <HiSun className="h-4 w-4" />
             )}
           </button>
         </div>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -37,7 +37,7 @@ export const Header: React.FC = () => {
   };
 
   return (
-    <header className="sticky top-0 z-50 border-b bg-background/90 backdrop-blur-xl supports-[backdrop-filter]:bg-background/75">
+    <header className="sticky top-0 z-50 border-b border-border/80 bg-background/88 backdrop-blur-xl supports-[backdrop-filter]:bg-background/72">
       <PageContainer className="py-3" contentClassName="flex items-center justify-between gap-4">
         <div className="flex min-w-0 items-center gap-3">
           {router.pathname !== '/' && (
@@ -47,7 +47,7 @@ export const Header: React.FC = () => {
             </Button>
           )}
           <Link href="/" className="min-w-0">
-            <p className="truncate text-sm font-semibold tracking-[0.14em] text-foreground/80 uppercase">
+            <p className="truncate text-sm font-medium tracking-[0.18em] text-foreground/70 uppercase">
               WebToolBox
             </p>
           </Link>
@@ -55,7 +55,7 @@ export const Header: React.FC = () => {
 
         <div className="flex items-center gap-2 sm:gap-3">
           <Select value={language} onValueChange={(value) => setLanguage(value as Language)}>
-            <SelectTrigger className="h-10 w-[120px] rounded-full sm:w-[140px]" data-testid="language-selector">
+            <SelectTrigger className="h-10 w-[120px] rounded-full border-border/80 bg-card/80 sm:w-[140px]" data-testid="language-selector">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -69,7 +69,7 @@ export const Header: React.FC = () => {
 
           <button
             onClick={toggleTheme}
-            className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-input bg-background transition-colors hover:bg-accent hover:text-accent-foreground"
+            className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-input bg-card/80 transition-colors hover:bg-accent hover:text-accent-foreground"
             aria-label={t('common.header.themeToggleAriaLabel')}
             data-testid="theme-toggle"
           >

--- a/components/layout/PageContainer.tsx
+++ b/components/layout/PageContainer.tsx
@@ -14,8 +14,8 @@ export function PageContainer({
   contentClassName,
 }: PageContainerProps) {
   return (
-    <div className={joinClasses("px-4 py-6 sm:px-6 sm:py-8", className)}>
-      <div className={joinClasses("mx-auto w-full max-w-screen-2xl", contentClassName)}>
+    <div className={joinClasses("px-4 py-8 sm:px-6 sm:py-10 lg:px-8", className)}>
+      <div className={joinClasses("mx-auto w-full max-w-6xl", contentClassName)}>
         {children}
       </div>
     </div>

--- a/components/layout/UtilsLayout.tsx
+++ b/components/layout/UtilsLayout.tsx
@@ -10,12 +10,12 @@ type UtilsLayoutProps = {
 export default function UtilsLayout({ children, onPaste, title, description }: UtilsLayoutProps) {
   return (
     <div className="bg-background" onPaste={onPaste}>
-      <PageContainer contentClassName="space-y-6">
-        <main>
+      <PageContainer contentClassName="space-y-8">
+        <main className="space-y-8">
           {(title || description) && (
-            <div className="mb-6">
-              {title && <h1 className="text-2xl font-bold">{title}</h1>}
-              {description && <p className="text-muted-foreground">{description}</p>}
+            <div className="max-w-3xl space-y-2">
+              {title && <h1 className="text-balance text-3xl font-semibold tracking-tight sm:text-4xl">{title}</h1>}
+              {description && <p className="text-pretty text-base leading-7 text-muted-foreground sm:text-lg">{description}</p>}
             </div>
           )}
           {children}

--- a/components/navigation/LinkCard.tsx
+++ b/components/navigation/LinkCard.tsx
@@ -12,19 +12,22 @@ type LinkCardProps = {
 export function LinkCard({ href, title, description, icon }: LinkCardProps) {
   return (
     <Link href={href} className="group block h-full">
-      <Card className="flex h-full flex-col justify-between">
-        <CardHeader className="space-y-4 pb-4">
+      <Card className="flex h-full flex-col justify-between overflow-hidden bg-card/95 transition-transform duration-200 group-hover:-translate-y-0.5">
+        <CardHeader className="space-y-5 pb-5">
           {icon && (
-            <div className="flex h-11 w-11 items-center justify-center rounded-full border bg-muted/40 text-muted-foreground transition-colors group-hover:border-foreground/15 group-hover:text-foreground">
+            <div className="flex h-11 w-11 items-center justify-center rounded-full border border-border/80 bg-muted/50 text-muted-foreground transition-colors group-hover:border-foreground/15 group-hover:text-foreground">
               {icon}
             </div>
           )}
-          <CardTitle className="text-lg font-medium leading-6 sm:text-xl">
-            {title}
-          </CardTitle>
+          <div className="space-y-3">
+            <CardTitle className="text-lg font-medium leading-6 sm:text-[1.45rem]">
+              {title}
+            </CardTitle>
+            <div className="h-px w-12 bg-border transition-all duration-200 group-hover:w-16 group-hover:bg-foreground/20" />
+          </div>
         </CardHeader>
         <CardContent>
-          <p className="text-sm leading-6 text-muted-foreground sm:text-[15px]">
+          <p className="text-sm leading-7 text-muted-foreground sm:text-[15px]">
             {description}
           </p>
         </CardContent>

--- a/components/navigation/LinkCard.tsx
+++ b/components/navigation/LinkCard.tsx
@@ -12,22 +12,21 @@ type LinkCardProps = {
 export function LinkCard({ href, title, description, icon }: LinkCardProps) {
   return (
     <Link href={href} className="group block h-full">
-      <Card className="flex h-full flex-col justify-between overflow-hidden bg-card/95 transition-transform duration-200 group-hover:-translate-y-0.5">
-        <CardHeader className="space-y-5 pb-5">
+      <Card className="flex h-full flex-col justify-between border-border/80 bg-card transition-all duration-100 group-hover:border-primary/25">
+        <CardHeader className="space-y-4 pb-4">
           {icon && (
-            <div className="flex h-11 w-11 items-center justify-center rounded-full border border-border/80 bg-muted/50 text-muted-foreground transition-colors group-hover:border-foreground/15 group-hover:text-foreground">
+            <div className="flex h-11 w-11 items-center justify-center rounded-2xl border border-border bg-muted/50 text-primary transition-colors duration-100 group-hover:bg-accent">
               {icon}
             </div>
           )}
-          <div className="space-y-3">
-            <CardTitle className="text-lg font-medium leading-6 sm:text-[1.45rem]">
+          <div className="space-y-2">
+            <CardTitle className="text-lg font-semibold leading-6 sm:text-xl">
               {title}
             </CardTitle>
-            <div className="h-px w-12 bg-border transition-all duration-200 group-hover:w-16 group-hover:bg-foreground/20" />
           </div>
         </CardHeader>
         <CardContent>
-          <p className="text-sm leading-7 text-muted-foreground sm:text-[15px]">
+          <p className="text-sm leading-6 text-muted-foreground sm:text-[15px]">
             {description}
           </p>
         </CardContent>

--- a/components/navigation/LinkCard.tsx
+++ b/components/navigation/LinkCard.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from "react";
+import Link from "next/link";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+type LinkCardProps = {
+  href: string;
+  title: string;
+  description: string;
+  icon?: ReactNode;
+};
+
+export function LinkCard({ href, title, description, icon }: LinkCardProps) {
+  return (
+    <Link href={href} className="group block h-full">
+      <Card className="flex h-full flex-col justify-between">
+        <CardHeader className="space-y-4 pb-4">
+          {icon && (
+            <div className="flex h-11 w-11 items-center justify-center rounded-full border bg-muted/40 text-muted-foreground transition-colors group-hover:border-foreground/15 group-hover:text-foreground">
+              {icon}
+            </div>
+          )}
+          <CardTitle className="text-lg font-medium leading-6 sm:text-xl">
+            {title}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm leading-6 text-muted-foreground sm:text-[15px]">
+            {description}
+          </p>
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}

--- a/components/navigation/PageIntro.tsx
+++ b/components/navigation/PageIntro.tsx
@@ -18,16 +18,16 @@ export function PageIntro({ title, description, align = "left", eyebrow }: PageI
       )}
     >
       {eyebrow && (
-        <p className="text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground/90">
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-primary">
           {eyebrow}
         </p>
       )}
       <div className="space-y-3">
-        <h1 className="text-balance text-4xl font-medium leading-[1.02] tracking-tight sm:text-5xl lg:text-6xl">
+        <h1 className="text-balance text-4xl font-semibold tracking-tight sm:text-5xl lg:text-6xl">
           {title}
         </h1>
         {description && (
-          <p className="text-pretty text-base leading-8 text-muted-foreground sm:text-lg lg:text-[1.15rem]">
+          <p className="text-pretty text-base leading-7 text-muted-foreground sm:text-lg">
             {description}
           </p>
         )}

--- a/components/navigation/PageIntro.tsx
+++ b/components/navigation/PageIntro.tsx
@@ -18,16 +18,16 @@ export function PageIntro({ title, description, align = "left", eyebrow }: PageI
       )}
     >
       {eyebrow && (
-        <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+        <p className="text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground/90">
           {eyebrow}
         </p>
       )}
-      <div className="space-y-2">
-        <h1 className="text-balance text-3xl font-semibold tracking-tight sm:text-4xl">
+      <div className="space-y-3">
+        <h1 className="text-balance text-4xl font-medium leading-[1.02] tracking-tight sm:text-5xl lg:text-6xl">
           {title}
         </h1>
         {description && (
-          <p className="text-pretty text-base leading-7 text-muted-foreground sm:text-lg">
+          <p className="text-pretty text-base leading-8 text-muted-foreground sm:text-lg lg:text-[1.15rem]">
             {description}
           </p>
         )}

--- a/components/navigation/PageIntro.tsx
+++ b/components/navigation/PageIntro.tsx
@@ -1,0 +1,37 @@
+type PageIntroProps = {
+  title: string;
+  description?: string;
+  align?: "left" | "center";
+  eyebrow?: string;
+};
+
+function joinClasses(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(" ");
+}
+
+export function PageIntro({ title, description, align = "left", eyebrow }: PageIntroProps) {
+  return (
+    <section
+      className={joinClasses(
+        "space-y-3",
+        align === "center" && "mx-auto max-w-3xl text-center"
+      )}
+    >
+      {eyebrow && (
+        <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+          {eyebrow}
+        </p>
+      )}
+      <div className="space-y-2">
+        <h1 className="text-balance text-3xl font-semibold tracking-tight sm:text-4xl">
+          {title}
+        </h1>
+        {description && (
+          <p className="text-pretty text-base leading-7 text-muted-foreground sm:text-lg">
+            {description}
+          </p>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -5,15 +5,15 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-full text-sm font-medium ring-offset-background transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-xl text-sm font-medium ring-offset-background transition-all duration-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:opacity-92",
+        default: "bg-primary text-primary-foreground shadow-sm hover:opacity-95",
         destructive:
           "bg-destructive text-destructive-foreground hover:opacity-90",
         outline:
-          "border border-input bg-background hover:border-foreground/20 hover:bg-accent hover:text-accent-foreground",
+          "border border-input bg-background hover:border-primary/25 hover:bg-accent hover:text-accent-foreground",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
@@ -23,7 +23,7 @@ const buttonVariants = cva(
         default: "h-11 px-5 py-2.5",
         sm: "h-9 px-3.5",
         lg: "h-12 px-8 text-base",
-        icon: "h-10 w-10 rounded-full", 
+        icon: "h-10 w-10 rounded-xl", 
       },
     },
     defaultVariants: {

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -5,25 +5,25 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-full text-sm font-medium ring-offset-background transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {
-        default: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        default: "bg-primary text-primary-foreground hover:opacity-92",
         destructive:
-          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+          "bg-destructive text-destructive-foreground hover:opacity-90",
         outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+          "border border-input bg-background hover:border-foreground/20 hover:bg-accent hover:text-accent-foreground",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
-        icon: "h-10 w-10",
+        default: "h-11 px-5 py-2.5",
+        sm: "h-9 px-3.5",
+        lg: "h-12 px-8 text-base",
+        icon: "h-10 w-10 rounded-full", 
       },
     },
     defaultVariants: {

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      "rounded-3xl border bg-card text-card-foreground shadow-[0_1px_0_rgba(15,23,42,0.02)] transition-all duration-200",
       className
     )}
     {...props}
@@ -23,7 +23,7 @@ const CardHeader = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    className={cn("flex flex-col space-y-2 p-6 sm:p-7", className)}
     {...props}
   />
 ))
@@ -36,7 +36,7 @@ const CardTitle = React.forwardRef<
   <h3
     ref={ref}
     className={cn(
-      "text-2xl font-semibold leading-none tracking-tight",
+      "text-xl font-semibold leading-tight tracking-tight text-balance",
       className
     )}
     {...props}
@@ -60,7 +60,7 @@ const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+  <div ref={ref} className={cn("p-6 pt-0 sm:p-7 sm:pt-0", className)} {...props} />
 ))
 CardContent.displayName = "CardContent"
 

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-3xl border bg-card text-card-foreground shadow-[0_1px_0_rgba(15,23,42,0.02)] transition-all duration-200",
+      "rounded-[28px] border bg-card text-card-foreground shadow-[0_1px_0_rgba(15,23,42,0.02)] transition-all duration-200 hover:border-foreground/10",
       className
     )}
     {...props}
@@ -23,7 +23,7 @@ const CardHeader = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex flex-col space-y-2 p-6 sm:p-7", className)}
+    className={cn("flex flex-col space-y-3 p-6 sm:p-8", className)}
     {...props}
   />
 ))
@@ -36,7 +36,7 @@ const CardTitle = React.forwardRef<
   <h3
     ref={ref}
     className={cn(
-      "text-xl font-semibold leading-tight tracking-tight text-balance",
+      "text-xl font-semibold leading-tight tracking-tight text-balance sm:text-[1.45rem]",
       className
     )}
     {...props}
@@ -60,7 +60,7 @@ const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("p-6 pt-0 sm:p-7 sm:pt-0", className)} {...props} />
+  <div ref={ref} className={cn("p-6 pt-0 sm:p-8 sm:pt-0", className)} {...props} />
 ))
 CardContent.displayName = "CardContent"
 

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-[28px] border bg-card text-card-foreground shadow-[0_1px_0_rgba(15,23,42,0.02)] transition-all duration-200 hover:border-foreground/10",
+      "rounded-3xl border bg-card text-card-foreground shadow-sm transition-all duration-100 hover:-translate-y-0.5 hover:shadow-md",
       className
     )}
     {...props}
@@ -23,7 +23,7 @@ const CardHeader = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex flex-col space-y-3 p-6 sm:p-8", className)}
+    className={cn("flex flex-col space-y-2 p-6 sm:p-7", className)}
     {...props}
   />
 ))
@@ -36,7 +36,7 @@ const CardTitle = React.forwardRef<
   <h3
     ref={ref}
     className={cn(
-      "text-xl font-semibold leading-tight tracking-tight text-balance sm:text-[1.45rem]",
+      "text-xl font-semibold leading-tight tracking-tight text-balance",
       className
     )}
     {...props}
@@ -60,7 +60,7 @@ const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("p-6 pt-0 sm:p-8 sm:pt-0", className)} {...props} />
+  <div ref={ref} className={cn("p-6 pt-0 sm:p-7 sm:pt-0", className)} {...props} />
 ))
 CardContent.displayName = "CardContent"
 

--- a/lib/i18n/en.json
+++ b/lib/i18n/en.json
@@ -3,6 +3,16 @@
     "title": "Web Utils",
     "subtitle": "A collection of useful tools and utilities.",
     "backToCategories": "Back to Categories",
+    "home": {
+      "eyebrow": "Fast utility access",
+      "overviewTitle": "Platform overview",
+      "stats": {
+        "categories": "Core categories for quick browsing",
+        "tools": "Utilities across media, data, and workflow",
+        "languages": "Supported languages",
+        "browser": "Browser-based use without installation"
+      }
+    },
     "uploadZone": {
       "pasteHint": "Press Ctrl+V to paste from clipboard",
       "dragDropHint": "or drag & drop a file here"

--- a/lib/i18n/ja.json
+++ b/lib/i18n/ja.json
@@ -3,6 +3,16 @@
     "title": "ウェブユーティリティ",
     "subtitle": "便利なツールのコレクションです。",
     "backToCategories": "カテゴリに戻る",
+    "home": {
+      "eyebrow": "すばやく使えるユーティリティ",
+      "overviewTitle": "プラットフォーム概要",
+      "stats": {
+        "categories": "すばやく探せる主要カテゴリ",
+        "tools": "メディア、データ、作業フロー向けのユーティリティ",
+        "languages": "対応言語数",
+        "browser": "インストール不要でブラウザから利用可能"
+      }
+    },
     "uploadZone": {
       "pasteHint": "クリップボードから Ctrl+V を押して貼り付けます",
       "dragDropHint": "またはファイルをドラッグ & ドロップ"

--- a/lib/i18n/ko.json
+++ b/lib/i18n/ko.json
@@ -3,6 +3,16 @@
     "title": "웹 유틸",
     "subtitle": "실용적인 도구 모음입니다.",
     "backToCategories": "카테고리로 돌아가기",
+    "home": {
+      "eyebrow": "빠른 도구 탐색",
+      "overviewTitle": "플랫폼 개요",
+      "stats": {
+        "categories": "빠르게 둘러볼 수 있는 핵심 카테고리",
+        "tools": "이미지, 데이터, 작업 흐름 전반의 유틸리티",
+        "languages": "지원 언어 수",
+        "browser": "설치 없이 브라우저에서 바로 사용"
+      }
+    },
     "uploadZone": {
       "pasteHint": "클립보드에서 Ctrl+V 를 눌러 붙여넣으세요",
       "dragDropHint": "또는 파일을 드래그 & 드롭하세요"

--- a/lib/i18n/translations.ts
+++ b/lib/i18n/translations.ts
@@ -5,6 +5,16 @@ export interface Translation {
     title: string;
     subtitle: string;
     backToCategories: string;
+    home: {
+      eyebrow: string;
+      overviewTitle: string;
+      stats: {
+        categories: string;
+        tools: string;
+        languages: string;
+        browser: string;
+      };
+    };
     uploadZone: {
       pasteHint: string;
       dragDropHint: string;

--- a/lib/i18n/zh.json
+++ b/lib/i18n/zh.json
@@ -3,6 +3,16 @@
     "title": "网络工具",
     "subtitle": "实用工具的集合。",
     "backToCategories": "返回类别",
+    "home": {
+      "eyebrow": "快速访问工具",
+      "overviewTitle": "平台概览",
+      "stats": {
+        "categories": "便于快速浏览的核心分类",
+        "tools": "覆盖媒体、数据与工作流程的实用工具",
+        "languages": "支持的语言数量",
+        "browser": "无需安装，直接在浏览器中使用"
+      }
+    },
     "uploadZone": {
       "pasteHint": "从剪贴板按 Ctrl+V 粘贴",
       "dragDropHint": "或将文件拖放至此"

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,7 @@
 import "@/styles/globals.css";
 import type { AppProps } from "next/app";
 import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
 import { I18nProvider } from "@/lib/i18n/i18nContext";
 import { ThemeProvider } from "@/lib/theme/themeContext";
 import { Header } from "@/components/Header";
@@ -9,6 +10,22 @@ import { SeoHead } from "@/components/SeoHead";
 export default function App({ Component, pageProps }: AppProps) {
   const router = useRouter();
   const currentPath = router.asPath || router.pathname || "/";
+  const [isNavigating, setIsNavigating] = useState(false);
+
+  useEffect(() => {
+    const handleStart = () => setIsNavigating(true);
+    const handleEnd = () => setTimeout(() => setIsNavigating(false), 100);
+
+    router.events.on("routeChangeStart", handleStart);
+    router.events.on("routeChangeComplete", handleEnd);
+    router.events.on("routeChangeError", handleEnd);
+
+    return () => {
+      router.events.off("routeChangeStart", handleStart);
+      router.events.off("routeChangeComplete", handleEnd);
+      router.events.off("routeChangeError", handleEnd);
+    };
+  }, [router.events]);
 
   return (
     <ThemeProvider>
@@ -16,7 +33,9 @@ export default function App({ Component, pageProps }: AppProps) {
       <I18nProvider>
         <div className="min-h-screen bg-background text-foreground">
           <Header />
-          <Component {...pageProps} />
+          <div className={`transition-opacity duration-100 ${isNavigating ? "opacity-90" : "opacity-100"}`}>
+            <Component {...pageProps} />
+          </div>
         </div>
       </I18nProvider>
     </ThemeProvider>

--- a/pages/category/database.tsx
+++ b/pages/category/database.tsx
@@ -1,49 +1,41 @@
-import Link from 'next/link';
-import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { PageContainer } from '@/components/layout/PageContainer';
+import { LinkCard } from '@/components/navigation/LinkCard';
+import { PageIntro } from '@/components/navigation/PageIntro';
 import { useI18n } from '@/lib/i18n/i18nContext';
 
 export default function DatabaseCategoryPage() {
   const { t } = useI18n();
-  return (
-    <PageContainer contentClassName="space-y-8">
-      <div className="space-y-2">
-        <h1 className="text-3xl font-bold">{t('common.categories.database.title')}</h1>
-        <p className="text-muted-foreground">{t('common.categories.database.description')}</p>
-      </div>
 
-      <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 md:grid-cols-3 lg:gap-6">
-        <Link href="/utils/escaped-string-decoder" passHref>
-          <Card className="h-full hover:shadow-lg transition-shadow">
-            <CardHeader>
-              <CardTitle>{t('common.tools.escapedStringDecoder.title')}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-muted-foreground">{t('common.tools.escapedStringDecoder.description')}</p>
-            </CardContent>
-          </Card>
-        </Link>
-        <Link href="/utils/csv-sorter" passHref>
-          <Card className="h-full hover:shadow-lg transition-shadow">
-            <CardHeader>
-              <CardTitle>{t('common.tools.csvSorter.title')}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-muted-foreground">{t('common.tools.csvSorter.description')}</p>
-            </CardContent>
-          </Card>
-        </Link>
-        <Link href="/utils/xlsx-to-sql" passHref>
-          <Card className="h-full hover:shadow-lg transition-shadow">
-            <CardHeader>
-              <CardTitle>{t('common.tools.xlsxToSql.title')}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-muted-foreground">{t('common.tools.xlsxToSql.description')}</p>
-            </CardContent>
-          </Card>
-        </Link>
-      </div>
+  const tools = [
+    {
+      href: '/utils/escaped-string-decoder',
+      title: t('common.tools.escapedStringDecoder.title'),
+      description: t('common.tools.escapedStringDecoder.description'),
+    },
+    {
+      href: '/utils/csv-sorter',
+      title: t('common.tools.csvSorter.title'),
+      description: t('common.tools.csvSorter.description'),
+    },
+    {
+      href: '/utils/xlsx-to-sql',
+      title: t('common.tools.xlsxToSql.title'),
+      description: t('common.tools.xlsxToSql.description'),
+    },
+  ];
+
+  return (
+    <PageContainer contentClassName="space-y-10">
+      <PageIntro
+        title={t('common.categories.database.title')}
+        description={t('common.categories.database.description')}
+      />
+
+      <section className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        {tools.map((tool) => (
+          <LinkCard key={tool.href} {...tool} />
+        ))}
+      </section>
     </PageContainer>
   );
 }

--- a/pages/category/etc.tsx
+++ b/pages/category/etc.tsx
@@ -1,51 +1,41 @@
-import Link from 'next/link';
-import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { PageContainer } from '@/components/layout/PageContainer';
+import { LinkCard } from '@/components/navigation/LinkCard';
+import { PageIntro } from '@/components/navigation/PageIntro';
 import { useI18n } from '@/lib/i18n/i18nContext';
 
 export default function EtcCategoryPage() {
   const { t } = useI18n();
+
+  const tools = [
+    {
+      href: '/utils/discord-color-message-generator',
+      title: t('common.tools.discordColorMessageGenerator.title'),
+      description: t('common.tools.discordColorMessageGenerator.description'),
+    },
+    {
+      href: '/utils/booth-algorithm-multiplier',
+      title: t('common.tools.boothAlgorithmMultiplier.title'),
+      description: t('common.tools.boothAlgorithmMultiplier.description'),
+    },
+    {
+      href: '/utils/kakaotalk-chat-analyzer',
+      title: t('common.tools.kakaotalkChatAnalyzer.title'),
+      description: t('common.tools.kakaotalkChatAnalyzer.description'),
+    },
+  ];
+
   return (
-    <PageContainer contentClassName="space-y-8">
-      <div className="space-y-2">
-        <h1 className="text-3xl font-bold">{t('common.categories.etc.title')}</h1>
-        <p className="text-muted-foreground">{t('common.categories.etc.description')}</p>
-      </div>
+    <PageContainer contentClassName="space-y-10">
+      <PageIntro
+        title={t('common.categories.etc.title')}
+        description={t('common.categories.etc.description')}
+      />
 
-      <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 md:grid-cols-3 lg:gap-6">
-        <Link href="/utils/discord-color-message-generator" passHref>
-          <Card className="h-full hover:shadow-lg transition-colors">
-            <CardHeader>
-              <CardTitle>{t('common.tools.discordColorMessageGenerator.title')}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-muted-foreground">{t('common.tools.discordColorMessageGenerator.description')}</p>
-            </CardContent>
-          </Card>
-        </Link>
-
-        <Link href="/utils/booth-algorithm-multiplier" passHref>
-          <Card className="h-full hover:shadow-lg transition-colors">
-            <CardHeader>
-              <CardTitle>{t('common.tools.boothAlgorithmMultiplier.title')}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-muted-foreground">{t('common.tools.boothAlgorithmMultiplier.description')}</p>
-            </CardContent>
-          </Card>
-        </Link>
-
-        <Link href="/utils/kakaotalk-chat-analyzer" passHref>
-          <Card className="h-full hover:shadow-lg transition-colors">
-            <CardHeader>
-              <CardTitle>{t('common.tools.kakaotalkChatAnalyzer.title')}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-muted-foreground">{t('common.tools.kakaotalkChatAnalyzer.description')}</p>
-            </CardContent>
-          </Card>
-        </Link>
-      </div>
+      <section className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        {tools.map((tool) => (
+          <LinkCard key={tool.href} {...tool} />
+        ))}
+      </section>
     </PageContainer>
   );
 }

--- a/pages/category/game.tsx
+++ b/pages/category/game.tsx
@@ -1,39 +1,36 @@
-import Link from 'next/link';
-import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { PageContainer } from '@/components/layout/PageContainer';
+import { LinkCard } from '@/components/navigation/LinkCard';
+import { PageIntro } from '@/components/navigation/PageIntro';
 import { useI18n } from '@/lib/i18n/i18nContext';
 
 export default function GameCategoryPage() {
   const { t } = useI18n();
-  return (
-    <PageContainer contentClassName="space-y-8">
-      <div className="space-y-2">
-        <h1 className="text-3xl font-bold">{t('common.categories.game.title')}</h1>
-        <p className="text-muted-foreground">{t('common.categories.game.description')}</p>
-      </div>
 
-      <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 md:grid-cols-3 lg:gap-6">
-        <Link href="/utils/tetrio-replay-editor" passHref>
-          <Card className="h-full hover:shadow-lg transition-colors">
-            <CardHeader>
-              <CardTitle>Tetrio.replay-editor</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-muted-foreground">Edit Tetrio replay files.</p>
-            </CardContent>
-          </Card>
-        </Link>
-        <Link href="/utils/optical-puyo-reader" passHref>
-          <Card className="h-full hover:shadow-lg transition-colors">
-            <CardHeader>
-              <CardTitle>OPR(Optical Puyo Reader)</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-muted-foreground">Read Puyo Puyo fields from images.</p>
-            </CardContent>
-          </Card>
-        </Link>
-      </div>
+  const tools = [
+    {
+      href: '/utils/tetrio-replay-editor',
+      title: t('common.tools.tetrioReplayEditor.title'),
+      description: t('common.tools.tetrioReplayEditor.description'),
+    },
+    {
+      href: '/utils/optical-puyo-reader',
+      title: t('common.tools.opticalPuyoReader.title'),
+      description: t('common.tools.opticalPuyoReader.description'),
+    },
+  ];
+
+  return (
+    <PageContainer contentClassName="space-y-10">
+      <PageIntro
+        title={t('common.categories.game.title')}
+        description={t('common.categories.game.description')}
+      />
+
+      <section className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        {tools.map((tool) => (
+          <LinkCard key={tool.href} {...tool} />
+        ))}
+      </section>
     </PageContainer>
   );
 }

--- a/pages/category/geolocation.tsx
+++ b/pages/category/geolocation.tsx
@@ -1,39 +1,36 @@
-import Link from 'next/link';
-import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { PageContainer } from '@/components/layout/PageContainer';
+import { LinkCard } from '@/components/navigation/LinkCard';
+import { PageIntro } from '@/components/navigation/PageIntro';
 import { useI18n } from '@/lib/i18n/i18nContext';
 
 export default function GeolocationCategoryPage() {
   const { t } = useI18n();
-  return (
-    <PageContainer contentClassName="space-y-8">
-      <div className="space-y-2">
-        <h1 className="text-3xl font-bold">{t('common.categories.geolocation.title')}</h1>
-        <p className="text-muted-foreground">{t('common.categories.geolocation.description')}</p>
-      </div>
 
-      <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 md:grid-cols-3 lg:gap-6">
-        <Link href="/utils/kakaomap-coord-opener" passHref>
-          <Card className="h-full hover:shadow-lg transition-colors">
-            <CardHeader>
-              <CardTitle>KakaoMap Coord Opener</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-muted-foreground">Open coordinates in KakaoMap.</p>
-            </CardContent>
-          </Card>
-        </Link>
-        <Link href="/utils/ntrip-scanner" passHref>
-          <Card className="h-full hover:shadow-lg transition-colors">
-            <CardHeader>
-              <CardTitle>NTRIP Mount Point Scanner</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-muted-foreground">Scan for NTRIP mount points.</p>
-            </CardContent>
-          </Card>
-        </Link>
-      </div>
+  const tools = [
+    {
+      href: '/utils/kakaomap-coord-opener',
+      title: t('common.tools.kakaomapCoordOpener.title'),
+      description: t('common.tools.kakaomapCoordOpener.description'),
+    },
+    {
+      href: '/utils/ntrip-scanner',
+      title: t('common.tools.ntripScanner.title'),
+      description: t('common.tools.ntripScanner.description'),
+    },
+  ];
+
+  return (
+    <PageContainer contentClassName="space-y-10">
+      <PageIntro
+        title={t('common.categories.geolocation.title')}
+        description={t('common.categories.geolocation.description')}
+      />
+
+      <section className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        {tools.map((tool) => (
+          <LinkCard key={tool.href} {...tool} />
+        ))}
+      </section>
     </PageContainer>
   );
 }

--- a/pages/category/gif.tsx
+++ b/pages/category/gif.tsx
@@ -1,79 +1,56 @@
-import Link from 'next/link';
-import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { PageContainer } from '@/components/layout/PageContainer';
+import { LinkCard } from '@/components/navigation/LinkCard';
+import { PageIntro } from '@/components/navigation/PageIntro';
 import { useI18n } from '@/lib/i18n/i18nContext';
 
 export default function GifCategoryPage() {
   const { t } = useI18n();
-  return (
-    <PageContainer contentClassName="space-y-8">
-      <div className="space-y-2">
-        <h1 className="text-3xl font-bold">{t('common.categories.gif.title')}</h1>
-        <p className="text-muted-foreground">{t('common.categories.gif.description')}</p>
-      </div>
 
-      <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 md:grid-cols-3 lg:gap-6">
-        <Link href="/utils/mp4-to-gif" passHref>
-          <Card className="h-full hover:shadow-lg transition-colors">
-            <CardHeader>
-              <CardTitle>{t('common.tools.mp4ToGif.title')}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-muted-foreground">{t('common.tools.mp4ToGif.description')}</p>
-            </CardContent>
-          </Card>
-        </Link>
-        <Link href="/utils/gif-to-mp4-webp" passHref>
-          <Card className="h-full hover:shadow-lg transition-colors">
-            <CardHeader>
-              <CardTitle>{t('common.tools.gifToMp4Webp.title')}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-muted-foreground">{t('common.tools.gifToMp4Webp.description')}</p>
-            </CardContent>
-          </Card>
-        </Link>
-        <Link href="/utils/gif-optimizer" passHref>
-          <Card className="h-full hover:shadow-lg transition-colors">
-            <CardHeader>
-              <CardTitle>{t('common.tools.gifOptimizer.title')}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-muted-foreground">{t('common.tools.gifOptimizer.description')}</p>
-            </CardContent>
-          </Card>
-        </Link>
-        <Link href="/utils/gif-speed-changer" passHref>
-          <Card className="h-full hover:shadow-lg transition-colors">
-            <CardHeader>
-              <CardTitle>{t('common.tools.gifSpeedChanger.title')}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-muted-foreground">{t('common.tools.gifSpeedChanger.description')}</p>
-            </CardContent>
-          </Card>
-        </Link>
-        <Link href="/utils/gif-crop" passHref>
-          <Card className="h-full hover:shadow-lg transition-colors">
-            <CardHeader>
-              <CardTitle>{t('common.tools.gifCrop.title')}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-muted-foreground">{t('common.tools.gifCrop.description')}</p>
-            </CardContent>
-          </Card>
-        </Link>
-        <Link href="/utils/gif-cutter" passHref>
-          <Card className="h-full hover:shadow-lg transition-colors">
-            <CardHeader>
-              <CardTitle>{t('common.tools.gifCutter.title')}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-muted-foreground">{t('common.tools.gifCutter.description')}</p>
-            </CardContent>
-          </Card>
-        </Link>
-      </div>
+  const tools = [
+    {
+      href: '/utils/mp4-to-gif',
+      title: t('common.tools.mp4ToGif.title'),
+      description: t('common.tools.mp4ToGif.description'),
+    },
+    {
+      href: '/utils/gif-to-mp4-webp',
+      title: t('common.tools.gifToMp4Webp.title'),
+      description: t('common.tools.gifToMp4Webp.description'),
+    },
+    {
+      href: '/utils/gif-optimizer',
+      title: t('common.tools.gifOptimizer.title'),
+      description: t('common.tools.gifOptimizer.description'),
+    },
+    {
+      href: '/utils/gif-speed-changer',
+      title: t('common.tools.gifSpeedChanger.title'),
+      description: t('common.tools.gifSpeedChanger.description'),
+    },
+    {
+      href: '/utils/gif-crop',
+      title: t('common.tools.gifCrop.title'),
+      description: t('common.tools.gifCrop.description'),
+    },
+    {
+      href: '/utils/gif-cutter',
+      title: t('common.tools.gifCutter.title'),
+      description: t('common.tools.gifCutter.description'),
+    },
+  ];
+
+  return (
+    <PageContainer contentClassName="space-y-10">
+      <PageIntro
+        title={t('common.categories.gif.title')}
+        description={t('common.categories.gif.description')}
+      />
+
+      <section className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        {tools.map((tool) => (
+          <LinkCard key={tool.href} {...tool} />
+        ))}
+      </section>
     </PageContainer>
   );
 }

--- a/pages/category/image-video.tsx
+++ b/pages/category/image-video.tsx
@@ -1,129 +1,81 @@
-import Link from 'next/link';
-import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { PageContainer } from '@/components/layout/PageContainer';
+import { LinkCard } from '@/components/navigation/LinkCard';
+import { PageIntro } from '@/components/navigation/PageIntro';
 import { useI18n } from '@/lib/i18n/i18nContext';
 
 export default function ImageVideoCategoryPage() {
   const { t } = useI18n();
-  return (
-    <PageContainer contentClassName="space-y-8">
-      <div className="space-y-2">
-        <h1 className="text-3xl font-bold">{t('common.categories.imageVideo.title')}</h1>
-        <p className="text-muted-foreground">{t('common.categories.imageVideo.description')}</p>
-      </div>
 
-      <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 md:grid-cols-3 lg:gap-6">
-        <Link href="/utils/image-to-base64" passHref>
-          <Card className="h-full hover:shadow-lg transition-colors">
-            <CardHeader>
-              <CardTitle>{t('common.tools.imageToBase64.title')}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-muted-foreground">{t('common.tools.imageToBase64.description')}</p>
-            </CardContent>
-          </Card>
-        </Link>
-        <Link href="/utils/video-cutter-encoder" passHref>
-          <Card className="h-full hover:shadow-lg transition-colors">
-            <CardHeader>
-              <CardTitle>{t('common.tools.videoCutterEncoder.title')}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-muted-foreground">{t('common.tools.videoCutterEncoder.description')}</p>
-            </CardContent>
-          </Card>
-        </Link>
-        <Link href="/utils/qr-code-generator" passHref>
-          <Card className="h-full hover:shadow-lg transition-colors">
-            <CardHeader>
-              <CardTitle>{t('common.tools.qrCode.title')}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-muted-foreground">{t('common.tools.qrCode.description')}</p>
-            </CardContent>
-          </Card>
-        </Link>
-        <Link href="/utils/svg-preview" passHref>
-          <Card className="h-full hover:shadow-lg transition-colors">
-            <CardHeader>
-              <CardTitle>{t('common.tools.svgPreview.title')}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-muted-foreground">{t('common.tools.svgPreview.description')}</p>
-            </CardContent>
-          </Card>
-        </Link>
-        <Link href="/utils/video-recorder" passHref>
-          <Card className="h-full hover:shadow-lg transition-colors">
-            <CardHeader>
-              <CardTitle>{t('common.tools.videoRecorder.title')}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-muted-foreground">{t('common.tools.videoRecorder.description')}</p>
-            </CardContent>
-          </Card>
-        </Link>
-        <Link href="/utils/gif-crop" passHref>
-          <Card className="h-full hover:shadow-lg transition-colors">
-            <CardHeader>
-              <CardTitle>{t('common.tools.gifCrop.title')}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-muted-foreground">{t('common.tools.gifCrop.description')}</p>
-            </CardContent>
-          </Card>
-        </Link>
-        <Link href="/utils/gif-cutter" passHref>
-          <Card className="h-full hover:shadow-lg transition-colors">
-            <CardHeader>
-              <CardTitle>{t('common.tools.gifCutter.title')}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-muted-foreground">{t('common.tools.gifCutter.description')}</p>
-            </CardContent>
-          </Card>
-        </Link>
-        <Link href="/utils/gif-speed-changer" passHref>
-          <Card className="h-full hover:shadow-lg transition-colors">
-            <CardHeader>
-              <CardTitle>{t('common.tools.gifSpeedChanger.title')}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-muted-foreground">{t('common.tools.gifSpeedChanger.description')}</p>
-            </CardContent>
-          </Card>
-        </Link>
-        <Link href="/utils/gif-to-mp4-webp" passHref>
-          <Card className="h-full hover:shadow-lg transition-colors">
-            <CardHeader>
-              <CardTitle>{t('common.tools.gifToMp4Webp.title')}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-muted-foreground">{t('common.tools.gifToMp4Webp.description')}</p>
-            </CardContent>
-          </Card>
-        </Link>
-        <Link href="/utils/gif-optimizer" passHref>
-          <Card className="h-full hover:shadow-lg transition-colors">
-            <CardHeader>
-              <CardTitle>{t('common.tools.gifOptimizer.title')}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-muted-foreground">{t('common.tools.gifOptimizer.description')}</p>
-            </CardContent>
-          </Card>
-        </Link>
-        <Link href="/utils/mp4-to-gif" passHref>
-          <Card className="h-full hover:shadow-lg transition-colors">
-            <CardHeader>
-              <CardTitle>{t('common.tools.mp4ToGif.title')}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-muted-foreground">{t('common.tools.mp4ToGif.description')}</p>
-            </CardContent>
-          </Card>
-        </Link>
-      </div>
+  const tools = [
+    {
+      href: '/utils/image-to-base64',
+      title: t('common.tools.imageToBase64.title'),
+      description: t('common.tools.imageToBase64.description'),
+    },
+    {
+      href: '/utils/video-cutter-encoder',
+      title: t('common.tools.videoCutterEncoder.title'),
+      description: t('common.tools.videoCutterEncoder.description'),
+    },
+    {
+      href: '/utils/qr-code-generator',
+      title: t('common.tools.qrCode.title'),
+      description: t('common.tools.qrCode.description'),
+    },
+    {
+      href: '/utils/svg-preview',
+      title: t('common.tools.svgPreview.title'),
+      description: t('common.tools.svgPreview.description'),
+    },
+    {
+      href: '/utils/video-recorder',
+      title: t('common.tools.videoRecorder.title'),
+      description: t('common.tools.videoRecorder.description'),
+    },
+    {
+      href: '/utils/gif-crop',
+      title: t('common.tools.gifCrop.title'),
+      description: t('common.tools.gifCrop.description'),
+    },
+    {
+      href: '/utils/gif-cutter',
+      title: t('common.tools.gifCutter.title'),
+      description: t('common.tools.gifCutter.description'),
+    },
+    {
+      href: '/utils/gif-speed-changer',
+      title: t('common.tools.gifSpeedChanger.title'),
+      description: t('common.tools.gifSpeedChanger.description'),
+    },
+    {
+      href: '/utils/gif-to-mp4-webp',
+      title: t('common.tools.gifToMp4Webp.title'),
+      description: t('common.tools.gifToMp4Webp.description'),
+    },
+    {
+      href: '/utils/gif-optimizer',
+      title: t('common.tools.gifOptimizer.title'),
+      description: t('common.tools.gifOptimizer.description'),
+    },
+    {
+      href: '/utils/mp4-to-gif',
+      title: t('common.tools.mp4ToGif.title'),
+      description: t('common.tools.mp4ToGif.description'),
+    },
+  ];
+
+  return (
+    <PageContainer contentClassName="space-y-10">
+      <PageIntro
+        title={t('common.categories.imageVideo.title')}
+        description={t('common.categories.imageVideo.description')}
+      />
+
+      <section className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        {tools.map((tool) => (
+          <LinkCard key={tool.href} {...tool} />
+        ))}
+      </section>
     </PageContainer>
   );
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -54,13 +54,30 @@ export default function Home() {
   ];
 
   return (
-    <PageContainer contentClassName="space-y-10 sm:space-y-12">
-      <PageIntro
-        title={t('common.title')}
-        description={t('common.subtitle')}
-        align="center"
-        eyebrow="Utility library"
-      />
+    <PageContainer contentClassName="space-y-12 sm:space-y-16">
+      <section className="grid gap-10 lg:grid-cols-[minmax(0,1.25fr)_minmax(0,0.75fr)] lg:items-end">
+        <PageIntro
+          title={t('common.title')}
+          description={t('common.subtitle')}
+          eyebrow="Curated utility library"
+        />
+
+        <div className="rounded-[32px] border border-border/80 bg-card/70 p-6 sm:p-8">
+          <p className="text-sm font-medium uppercase tracking-[0.18em] text-muted-foreground">
+            Overview
+          </p>
+          <div className="mt-6 grid grid-cols-2 gap-6">
+            <div>
+              <p className="text-3xl font-medium text-foreground">6</p>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">Core categories arranged for browsing and quick access.</p>
+            </div>
+            <div>
+              <p className="text-3xl font-medium text-foreground">20+</p>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">Focused utilities for media, data, games, and everyday tasks.</p>
+            </div>
+          </div>
+        </div>
+      </section>
 
       <section className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
         {categories.map((category) => (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -59,27 +59,27 @@ export default function Home() {
         <PageIntro
           title={t('common.title')}
           description={t('common.subtitle')}
-          eyebrow="Fast utility access"
+          eyebrow={t('common.home.eyebrow')}
         />
 
         <div className="rounded-3xl border border-border bg-card p-6 shadow-sm sm:p-7">
-          <p className="text-sm font-semibold text-muted-foreground">Platform overview</p>
+          <p className="text-sm font-semibold text-muted-foreground">{t('common.home.overviewTitle')}</p>
           <div className="mt-5 grid grid-cols-2 gap-3">
             <div className="rounded-2xl border bg-muted/50 p-4">
               <p className="text-3xl font-semibold text-foreground">6</p>
-              <p className="mt-2 text-sm leading-6 text-muted-foreground">Core categories for quick browsing</p>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">{t('common.home.stats.categories')}</p>
             </div>
             <div className="rounded-2xl border bg-muted/50 p-4">
               <p className="text-3xl font-semibold text-foreground">20+</p>
-              <p className="mt-2 text-sm leading-6 text-muted-foreground">Utilities across media, data, and workflow</p>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">{t('common.home.stats.tools')}</p>
             </div>
             <div className="rounded-2xl border bg-muted/50 p-4">
               <p className="text-3xl font-semibold text-foreground">4</p>
-              <p className="mt-2 text-sm leading-6 text-muted-foreground">Supported languages</p>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">{t('common.home.stats.languages')}</p>
             </div>
             <div className="rounded-2xl border bg-muted/50 p-4">
               <p className="text-3xl font-semibold text-foreground">∞</p>
-              <p className="mt-2 text-sm leading-6 text-muted-foreground">Browser-based use without installation</p>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">{t('common.home.stats.browser')}</p>
             </div>
           </div>
         </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,101 +1,72 @@
-import Link from 'next/link';
-import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { PageContainer } from '@/components/layout/PageContainer';
+import { LinkCard } from '@/components/navigation/LinkCard';
+import { PageIntro } from '@/components/navigation/PageIntro';
 import {
-  HiCode,
+  HiCollection,
   HiDatabase,
+  HiLocationMarker,
+  HiPhotograph,
   HiPuzzle,
   HiVideoCamera,
-  HiLocationMarker,
-  HiCollection,
-  HiPhotograph,
 } from 'react-icons/hi';
 import { useI18n } from '@/lib/i18n/i18nContext';
 
 export default function Home() {
   const { t } = useI18n();
-  
+
+  const categories = [
+    {
+      href: '/category/database',
+      title: t('common.categories.database.title'),
+      description: t('common.categories.database.description'),
+      icon: <HiDatabase className="h-5 w-5" />,
+    },
+    {
+      href: '/category/game',
+      title: t('common.categories.game.title'),
+      description: t('common.categories.game.description'),
+      icon: <HiPuzzle className="h-5 w-5" />,
+    },
+    {
+      href: '/category/image-video',
+      title: t('common.categories.imageVideo.title'),
+      description: t('common.categories.imageVideo.description'),
+      icon: <HiVideoCamera className="h-5 w-5" />,
+    },
+    {
+      href: '/category/gif',
+      title: t('common.categories.gif.title'),
+      description: t('common.categories.gif.description'),
+      icon: <HiPhotograph className="h-5 w-5" />,
+    },
+    {
+      href: '/category/geolocation',
+      title: t('common.categories.geolocation.title'),
+      description: t('common.categories.geolocation.description'),
+      icon: <HiLocationMarker className="h-5 w-5" />,
+    },
+    {
+      href: '/category/etc',
+      title: t('common.categories.etc.title'),
+      description: t('common.categories.etc.description'),
+      icon: <HiCollection className="h-5 w-5" />,
+    },
+  ];
+
   return (
-    <PageContainer contentClassName="space-y-8">
-      <div className="space-y-2 text-center">
-        <h1 className="text-4xl font-bold">{t('common.title')}</h1>
-        <p className="text-xl text-muted-foreground">{t('common.subtitle')}</p>
-      </div>
-      <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 lg:gap-6">
+    <PageContainer contentClassName="space-y-10 sm:space-y-12">
+      <PageIntro
+        title={t('common.title')}
+        description={t('common.subtitle')}
+        align="center"
+        eyebrow="Utility library"
+      />
 
-        <Link href="/category/database" passHref>
-          <Card className="cursor-pointer hover:shadow-lg transition-shadow h-full">
-            <CardHeader className="flex flex-col items-center text-center">
-              <HiDatabase className="h-12 w-12 mb-4 text-muted-foreground" />
-              <CardTitle>{t('common.categories.database.title')}</CardTitle>
-            </CardHeader>
-            <CardContent className="text-center">
-              <p className="text-muted-foreground">{t('common.categories.database.description')}</p>
-            </CardContent>
-          </Card>
-        </Link>
-
-        <Link href="/category/game" passHref>
-          <Card className="cursor-pointer hover:shadow-lg transition-shadow h-full">
-            <CardHeader className="flex flex-col items-center text-center">
-              <HiPuzzle className="h-12 w-12 mb-4 text-muted-foreground" />
-              <CardTitle>{t('common.categories.game.title')}</CardTitle>
-            </CardHeader>
-            <CardContent className="text-center">
-              <p className="text-muted-foreground">{t('common.categories.game.description')}</p>
-            </CardContent>
-          </Card>
-        </Link>
-
-        <Link href="/category/image-video" passHref>
-          <Card className="cursor-pointer hover:shadow-lg transition-shadow h-full">
-            <CardHeader className="flex flex-col items-center text-center">
-              <HiVideoCamera className="h-12 w-12 mb-4 text-muted-foreground" />
-              <CardTitle>{t('common.categories.imageVideo.title')}</CardTitle>
-            </CardHeader>
-            <CardContent className="text-center">
-              <p className="text-muted-foreground">{t('common.categories.imageVideo.description')}</p>
-            </CardContent>
-          </Card>
-        </Link>
-
-        <Link href="/category/gif" passHref>
-          <Card className="cursor-pointer hover:shadow-lg transition-shadow h-full">
-            <CardHeader className="flex flex-col items-center text-center">
-              <HiPhotograph className="h-12 w-12 mb-4 text-muted-foreground" />
-              <CardTitle>{t('common.categories.gif.title')}</CardTitle>
-            </CardHeader>
-            <CardContent className="text-center">
-              <p className="text-muted-foreground">{t('common.categories.gif.description')}</p>
-            </CardContent>
-          </Card>
-        </Link>
-
-        <Link href="/category/geolocation" passHref>
-          <Card className="cursor-pointer hover:shadow-lg transition-shadow h-full">
-            <CardHeader className="flex flex-col items-center text-center">
-              <HiLocationMarker className="h-12 w-12 mb-4 text-muted-foreground" />
-              <CardTitle>{t('common.categories.geolocation.title')}</CardTitle>
-            </CardHeader>
-            <CardContent className="text-center">
-              <p className="text-muted-foreground">{t('common.categories.geolocation.description')}</p>
-            </CardContent>
-          </Card>
-        </Link>
-
-        <Link href="/category/etc" passHref>
-          <Card className="cursor-pointer hover:shadow-lg transition-shadow h-full">
-            <CardHeader className="flex flex-col items-center text-center">
-              <HiCollection className="h-12 w-12 mb-4 text-muted-foreground" />
-              <CardTitle>{t('common.categories.etc.title')}</CardTitle>
-            </CardHeader>
-            <CardContent className="text-center">
-              <p className="text-muted-foreground">{t('common.categories.etc.description')}</p>
-            </CardContent>
-          </Card>
-        </Link>
-
-      </div>
+      <section className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        {categories.map((category) => (
+          <LinkCard key={category.href} {...category} />
+        ))}
+      </section>
     </PageContainer>
   );
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -54,26 +54,32 @@ export default function Home() {
   ];
 
   return (
-    <PageContainer contentClassName="space-y-12 sm:space-y-16">
-      <section className="grid gap-10 lg:grid-cols-[minmax(0,1.25fr)_minmax(0,0.75fr)] lg:items-end">
+    <PageContainer contentClassName="space-y-12 sm:space-y-14">
+      <section className="grid gap-8 lg:grid-cols-[minmax(0,1.2fr)_minmax(320px,0.8fr)] lg:items-start">
         <PageIntro
           title={t('common.title')}
           description={t('common.subtitle')}
-          eyebrow="Curated utility library"
+          eyebrow="Fast utility access"
         />
 
-        <div className="rounded-[32px] border border-border/80 bg-card/70 p-6 sm:p-8">
-          <p className="text-sm font-medium uppercase tracking-[0.18em] text-muted-foreground">
-            Overview
-          </p>
-          <div className="mt-6 grid grid-cols-2 gap-6">
-            <div>
-              <p className="text-3xl font-medium text-foreground">6</p>
-              <p className="mt-2 text-sm leading-6 text-muted-foreground">Core categories arranged for browsing and quick access.</p>
+        <div className="rounded-3xl border border-border bg-card p-6 shadow-sm sm:p-7">
+          <p className="text-sm font-semibold text-muted-foreground">Platform overview</p>
+          <div className="mt-5 grid grid-cols-2 gap-3">
+            <div className="rounded-2xl border bg-muted/50 p-4">
+              <p className="text-3xl font-semibold text-foreground">6</p>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">Core categories for quick browsing</p>
             </div>
-            <div>
-              <p className="text-3xl font-medium text-foreground">20+</p>
-              <p className="mt-2 text-sm leading-6 text-muted-foreground">Focused utilities for media, data, games, and everyday tasks.</p>
+            <div className="rounded-2xl border bg-muted/50 p-4">
+              <p className="text-3xl font-semibold text-foreground">20+</p>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">Utilities across media, data, and workflow</p>
+            </div>
+            <div className="rounded-2xl border bg-muted/50 p-4">
+              <p className="text-3xl font-semibold text-foreground">4</p>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">Supported languages</p>
+            </div>
+            <div className="rounded-2xl border bg-muted/50 p-4">
+              <p className="text-3xl font-semibold text-foreground">∞</p>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">Browser-based use without installation</p>
             </div>
           </div>
         </div>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,8 +1,8 @@
+@import url('https://fonts.googleapis.com/css2?family=Newsreader:opsz,wght@6..72,400;6..72,500;6..72,600&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-@import url('https://fonts.googleapis.com/css2?family=Newsreader:opsz,wght@6..72,400;6..72,500;6..72,600&display=swap');
 
 @layer base {
   :root {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -4,26 +4,26 @@
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
+    --background: 40 20% 97%;
+    --foreground: 222 20% 12%;
     --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
+    --card-foreground: 222 20% 12%;
     --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
-    --primary: 222.2 47.4% 11.2%;
-    --primary-foreground: 210 40% 98%;
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 222.2 84% 4.9%;
-    --radius: 0.5rem;
+    --popover-foreground: 222 20% 12%;
+    --primary: 222 22% 14%;
+    --primary-foreground: 40 20% 97%;
+    --secondary: 36 24% 93%;
+    --secondary-foreground: 222 20% 12%;
+    --muted: 36 24% 94%;
+    --muted-foreground: 220 10% 40%;
+    --accent: 36 24% 92%;
+    --accent-foreground: 222 20% 12%;
+    --destructive: 0 70% 52%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 30 14% 86%;
+    --input: 30 14% 86%;
+    --ring: 222 22% 18%;
+    --radius: 1rem;
     --chart-1: 12 76% 61%;
     --chart-2: 173 58% 39%;
     --chart-3: 197 37% 24%;
@@ -34,31 +34,41 @@
   * {
     @apply border-border;
   }
+
+  html {
+    scroll-behavior: smooth;
+  }
+
   body {
-    @apply bg-background text-foreground;
+    @apply min-h-screen bg-background text-foreground antialiased;
+    text-rendering: optimizeLegibility;
+  }
+
+  ::selection {
+    @apply bg-foreground text-background;
   }
 }
 
 .dark {
-  --background: 222.2 84% 4.9%;
-  --foreground: 210 40% 98%;
-  --card: 222.2 84% 4.9%;
-  --card-foreground: 210 40% 98%;
-  --popover: 222.2 84% 4.9%;
-  --popover-foreground: 210 40% 98%;
-  --primary: 210 40% 98%;
-  --primary-foreground: 222.2 47.4% 11.2%;
-  --secondary: 217.2 32.6% 17.5%;
-  --secondary-foreground: 210 40% 98%;
-  --muted: 217.2 32.6% 17.5%;
-  --muted-foreground: 215 20.2% 65.1%;
-  --accent: 217.2 32.6% 17.5%;
-  --accent-foreground: 210 40% 98%;
-  --destructive: 0 62.8% 30.6%;
-  --destructive-foreground: 210 40% 98%;
-  --border: 217.2 32.6% 17.5%;
-  --input: 217.2 32.6% 17.5%;
-  --ring: 212.7 26.8% 83.9%;
+  --background: 222 18% 9%;
+  --foreground: 35 20% 94%;
+  --card: 222 16% 11%;
+  --card-foreground: 35 20% 94%;
+  --popover: 222 16% 11%;
+  --popover-foreground: 35 20% 94%;
+  --primary: 35 20% 94%;
+  --primary-foreground: 222 18% 9%;
+  --secondary: 220 14% 15%;
+  --secondary-foreground: 35 20% 94%;
+  --muted: 220 14% 15%;
+  --muted-foreground: 220 8% 65%;
+  --accent: 220 14% 16%;
+  --accent-foreground: 35 20% 94%;
+  --destructive: 0 62% 42%;
+  --destructive-foreground: 35 20% 94%;
+  --border: 220 10% 20%;
+  --input: 220 10% 20%;
+  --ring: 35 20% 94%;
   --chart-1: 220 70% 50%;
   --chart-2: 160 60% 45%;
   --chart-3: 30 80% 55%;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2,28 +2,30 @@
 @tailwind components;
 @tailwind utilities;
 
+@import url('https://fonts.googleapis.com/css2?family=Newsreader:opsz,wght@6..72,400;6..72,500;6..72,600&display=swap');
+
 @layer base {
   :root {
-    --background: 40 20% 97%;
-    --foreground: 222 20% 12%;
+    --background: 36 33% 97%;
+    --foreground: 222 24% 12%;
     --card: 0 0% 100%;
-    --card-foreground: 222 20% 12%;
+    --card-foreground: 222 24% 12%;
     --popover: 0 0% 100%;
-    --popover-foreground: 222 20% 12%;
-    --primary: 222 22% 14%;
-    --primary-foreground: 40 20% 97%;
-    --secondary: 36 24% 93%;
-    --secondary-foreground: 222 20% 12%;
-    --muted: 36 24% 94%;
-    --muted-foreground: 220 10% 40%;
-    --accent: 36 24% 92%;
-    --accent-foreground: 222 20% 12%;
+    --popover-foreground: 222 24% 12%;
+    --primary: 222 20% 14%;
+    --primary-foreground: 36 33% 97%;
+    --secondary: 32 32% 94%;
+    --secondary-foreground: 222 24% 12%;
+    --muted: 30 26% 95%;
+    --muted-foreground: 220 10% 41%;
+    --accent: 24 42% 91%;
+    --accent-foreground: 222 24% 12%;
     --destructive: 0 70% 52%;
     --destructive-foreground: 0 0% 100%;
-    --border: 30 14% 86%;
-    --input: 30 14% 86%;
-    --ring: 222 22% 18%;
-    --radius: 1rem;
+    --border: 28 18% 86%;
+    --input: 28 18% 86%;
+    --ring: 18 48% 42%;
+    --radius: 1.25rem;
     --chart-1: 12 76% 61%;
     --chart-2: 173 58% 39%;
     --chart-3: 197 37% 24%;
@@ -42,6 +44,19 @@
   body {
     @apply min-h-screen bg-background text-foreground antialiased;
     text-rendering: optimizeLegibility;
+    background-image: radial-gradient(circle at top, rgba(182, 129, 74, 0.08), transparent 34%);
+    font-feature-settings: "liga" 1, "kern" 1;
+  }
+
+  h1,
+  h2,
+  h3 {
+    font-family: "Newsreader", Georgia, serif;
+    letter-spacing: -0.03em;
+  }
+
+  p {
+    text-wrap: pretty;
   }
 
   ::selection {
@@ -50,28 +65,32 @@
 }
 
 .dark {
-  --background: 222 18% 9%;
-  --foreground: 35 20% 94%;
-  --card: 222 16% 11%;
-  --card-foreground: 35 20% 94%;
-  --popover: 222 16% 11%;
-  --popover-foreground: 35 20% 94%;
-  --primary: 35 20% 94%;
-  --primary-foreground: 222 18% 9%;
-  --secondary: 220 14% 15%;
-  --secondary-foreground: 35 20% 94%;
-  --muted: 220 14% 15%;
-  --muted-foreground: 220 8% 65%;
-  --accent: 220 14% 16%;
-  --accent-foreground: 35 20% 94%;
+  --background: 222 16% 10%;
+  --foreground: 35 24% 94%;
+  --card: 222 14% 12%;
+  --card-foreground: 35 24% 94%;
+  --popover: 222 14% 12%;
+  --popover-foreground: 35 24% 94%;
+  --primary: 35 24% 94%;
+  --primary-foreground: 222 16% 10%;
+  --secondary: 220 12% 16%;
+  --secondary-foreground: 35 24% 94%;
+  --muted: 220 12% 15%;
+  --muted-foreground: 220 8% 67%;
+  --accent: 24 24% 18%;
+  --accent-foreground: 35 24% 94%;
   --destructive: 0 62% 42%;
-  --destructive-foreground: 35 20% 94%;
-  --border: 220 10% 20%;
-  --input: 220 10% 20%;
-  --ring: 35 20% 94%;
+  --destructive-foreground: 35 24% 94%;
+  --border: 220 10% 21%;
+  --input: 220 10% 21%;
+  --ring: 30 42% 68%;
   --chart-1: 220 70% 50%;
   --chart-2: 160 60% 45%;
   --chart-3: 30 80% 55%;
   --chart-4: 280 65% 60%;
   --chart-5: 340 75% 55%;
+}
+
+.dark body {
+  background-image: radial-gradient(circle at top, rgba(197, 151, 104, 0.08), transparent 30%);
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,31 +1,29 @@
-@import url('https://fonts.googleapis.com/css2?family=Newsreader:opsz,wght@6..72,400;6..72,500;6..72,600&display=swap');
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 @layer base {
   :root {
-    --background: 36 33% 97%;
-    --foreground: 222 24% 12%;
+    --background: 210 40% 98%;
+    --foreground: 222.2 47.4% 11.2%;
     --card: 0 0% 100%;
-    --card-foreground: 222 24% 12%;
+    --card-foreground: 222.2 47.4% 11.2%;
     --popover: 0 0% 100%;
-    --popover-foreground: 222 24% 12%;
-    --primary: 222 20% 14%;
-    --primary-foreground: 36 33% 97%;
-    --secondary: 32 32% 94%;
-    --secondary-foreground: 222 24% 12%;
-    --muted: 30 26% 95%;
-    --muted-foreground: 220 10% 41%;
-    --accent: 24 42% 91%;
-    --accent-foreground: 222 24% 12%;
-    --destructive: 0 70% 52%;
-    --destructive-foreground: 0 0% 100%;
-    --border: 28 18% 86%;
-    --input: 28 18% 86%;
-    --ring: 18 48% 42%;
-    --radius: 1.25rem;
+    --popover-foreground: 222.2 47.4% 11.2%;
+    --primary: 221 83% 53%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 210 40% 96.1%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
+    --muted: 210 40% 96.1%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+    --accent: 214 100% 97%;
+    --accent-foreground: 221 83% 53%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 214.3 31.8% 91.4%;
+    --input: 214.3 31.8% 91.4%;
+    --ring: 221 83% 53%;
+    --radius: 1rem;
     --chart-1: 12 76% 61%;
     --chart-2: 173 58% 39%;
     --chart-3: 197 37% 24%;
@@ -44,14 +42,11 @@
   body {
     @apply min-h-screen bg-background text-foreground antialiased;
     text-rendering: optimizeLegibility;
-    background-image: radial-gradient(circle at top, rgba(182, 129, 74, 0.08), transparent 34%);
-    font-feature-settings: "liga" 1, "kern" 1;
   }
 
   h1,
   h2,
   h3 {
-    font-family: "Newsreader", Georgia, serif;
     letter-spacing: -0.03em;
   }
 
@@ -60,37 +55,33 @@
   }
 
   ::selection {
-    @apply bg-foreground text-background;
+    @apply bg-primary text-primary-foreground;
   }
 }
 
 .dark {
-  --background: 222 16% 10%;
-  --foreground: 35 24% 94%;
-  --card: 222 14% 12%;
-  --card-foreground: 35 24% 94%;
-  --popover: 222 14% 12%;
-  --popover-foreground: 35 24% 94%;
-  --primary: 35 24% 94%;
-  --primary-foreground: 222 16% 10%;
-  --secondary: 220 12% 16%;
-  --secondary-foreground: 35 24% 94%;
-  --muted: 220 12% 15%;
-  --muted-foreground: 220 8% 67%;
-  --accent: 24 24% 18%;
-  --accent-foreground: 35 24% 94%;
-  --destructive: 0 62% 42%;
-  --destructive-foreground: 35 24% 94%;
-  --border: 220 10% 21%;
-  --input: 220 10% 21%;
-  --ring: 30 42% 68%;
+  --background: 222.2 84% 4.9%;
+  --foreground: 210 40% 98%;
+  --card: 222.2 47% 8%;
+  --card-foreground: 210 40% 98%;
+  --popover: 222.2 47% 8%;
+  --popover-foreground: 210 40% 98%;
+  --primary: 217.2 91.2% 59.8%;
+  --primary-foreground: 222.2 47.4% 11.2%;
+  --secondary: 217.2 32.6% 17.5%;
+  --secondary-foreground: 210 40% 98%;
+  --muted: 217.2 32.6% 17.5%;
+  --muted-foreground: 215 20.2% 65.1%;
+  --accent: 217.2 32.6% 17.5%;
+  --accent-foreground: 210 40% 98%;
+  --destructive: 0 62.8% 30.6%;
+  --destructive-foreground: 210 40% 98%;
+  --border: 217.2 32.6% 17.5%;
+  --input: 217.2 32.6% 17.5%;
+  --ring: 224.3 76.3% 48%;
   --chart-1: 220 70% 50%;
   --chart-2: 160 60% 45%;
   --chart-3: 30 80% 55%;
   --chart-4: 280 65% 60%;
   --chart-5: 340 75% 55%;
-}
-
-.dark body {
-  background-image: radial-gradient(circle at top, rgba(197, 151, 104, 0.08), transparent 30%);
 }


### PR DESCRIPTION
   ## Summary
   - apply a minimal visual refresh across the shared shell and category pages
   - introduce reusable `PageIntro` and `LinkCard` components for cleaner page composition
   - normalize game/geolocation category cards to use i18n-backed tool names and descriptions

   ## Changes
   - update global color tokens, spacing, radius, and base typography for a calmer neutral theme
   - refine shared UI primitives including cards, buttons, page container, utils layout, and header
   - rebuild the home page and all category pages around the new minimal card system
   - keep the scope focused on navigation/category surfaces without changing tool logic

   ## Validation
   - `pnpm typecheck`
   - `pnpm lint` *(fails currently because the repo does not have an ESLint v9 flat config such as `eslint.config.js`)*